### PR TITLE
Publisher rest v2

### DIFF
--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/EventTypesRestController.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/EventTypesRestController.java
@@ -76,7 +76,7 @@ public class EventTypesRestController {
      
      private final DataPointDao dataPointDao;
      private final DataSourceDao<?> dataSourceDao;
-     private final PublisherDao publisherDao;
+     private final PublisherDao<?> publisherDao;
      private final EventDetectorDao<?> eventDetectorDao;
      private final RestModelMapper modelMapper;
 
@@ -84,7 +84,7 @@ public class EventTypesRestController {
      public EventTypesRestController(
              DataPointDao dataPointDao,
              DataSourceDao<?> dataSourceDao,
-             PublisherDao publisherDao,
+             PublisherDao<?> publisherDao,
              EventDetectorDao<?> eventDetectorDao,
              RestModelMapper modelMapper) {
          this.dataPointDao = dataPointDao;

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/PublisherRestV2Controller.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/PublisherRestV2Controller.java
@@ -39,10 +39,10 @@ import com.serotonin.m2m2.vo.publish.PublisherVO;
 import com.serotonin.m2m2.web.mvc.rest.v1.model.QueryDataPageStream;
 import com.serotonin.m2m2.web.mvc.rest.v1.model.publisher.AbstractPublishedPointModel;
 import com.serotonin.m2m2.web.mvc.rest.v1.model.publisher.AbstractPublisherModel;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-
 import net.jazdw.rql.parser.ASTNode;
 
 /**
@@ -52,12 +52,13 @@ import net.jazdw.rql.parser.ASTNode;
 @Api(value="Publishers", description="Publishers endpoints")
 @RestController()
 @RequestMapping("/publishers")
-public class PublisherRestV2Controller extends AbstractMangoVoRestV2Controller<PublisherVO<?>, AbstractPublisherModel<?, ?>, PublisherDao>{
+public class PublisherRestV2Controller<T extends PublishedPointVO> extends AbstractMangoVoRestV2Controller<PublisherVO<T>, AbstractPublisherModel<?, ?>, PublisherDao<T>>{
 
     
     
-	public PublisherRestV2Controller(){
-		super(PublisherDao.getInstance());
+	@SuppressWarnings("unchecked")
+    public PublisherRestV2Controller(){
+		super((PublisherDao<T>) PublisherDao.getInstance());
 	}
 
 	@ApiOperation(
@@ -67,7 +68,7 @@ public class PublisherRestV2Controller extends AbstractMangoVoRestV2Controller<P
 			responseContainer="List"
 			)
 	@RequestMapping(method = RequestMethod.GET)
-    public ResponseEntity<QueryDataPageStream<PublisherVO<?>>> queryRQL(@AuthenticationPrincipal User user, HttpServletRequest request) {
+    public ResponseEntity<QueryDataPageStream<PublisherVO<T>>> queryRQL(@AuthenticationPrincipal User user, HttpServletRequest request) {
 		assertAdmin(user);
 		ASTNode node = RQLUtils.parseRQLtoAST(request.getQueryString());
 		return new ResponseEntity<>(getPageStream(node, user), HttpStatus.OK);		
@@ -80,7 +81,7 @@ public class PublisherRestV2Controller extends AbstractMangoVoRestV2Controller<P
     @RequestMapping(method = RequestMethod.GET, value = "/list")
     public ResponseEntity<List<AbstractPublisherModel<?,?>>> getAll(@AuthenticationPrincipal User user, HttpServletRequest request) {
 		assertAdmin(user);
-        List<PublisherVO<?>> publishers = this.dao.getAll();
+        List<PublisherVO<T>> publishers = this.dao.getAll();
         List<AbstractPublisherModel<?,?>> models = new ArrayList<AbstractPublisherModel<?,?>>();
         for(PublisherVO<?> pub : publishers)
    			models.add(pub.asModel());
@@ -197,15 +198,12 @@ public class PublisherRestV2Controller extends AbstractMangoVoRestV2Controller<P
 	 * @param user
 	 */
 	private void assertAdmin(User user){
-		if(!user.isAdmin())
+		if(!user.hasAdminPermission())
 			throw new AccessDeniedException(user.getUsername() + " not admin, permission denied.");
 	}
 	
-	/* (non-Javadoc)
-	 * @see com.serotonin.m2m2.web.mvc.rest.v1.MangoVoRestController#createModel(java.lang.Object)
-	 */
 	@Override
-	public AbstractPublisherModel<?,?> createModel(PublisherVO<?> vo) {
+	public AbstractPublisherModel<?,?> createModel(PublisherVO<T> vo) {
 		return vo.asModel();
 	}
 	

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/PublishersRestController.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/PublishersRestController.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (C) 2019  Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango.rest.v2;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.infiniteautomation.mango.rest.v2.model.RestModelMapper;
+import com.infiniteautomation.mango.rest.v2.model.StreamedArrayWithTotal;
+import com.infiniteautomation.mango.rest.v2.model.StreamedVORqlQueryWithTotal;
+import com.infiniteautomation.mango.rest.v2.model.publisher.AbstractPublisherModel;
+import com.infiniteautomation.mango.rest.v2.patch.PatchVORequestBody;
+import com.infiniteautomation.mango.spring.service.PublisherService;
+import com.infiniteautomation.mango.util.RQLUtils;
+import com.serotonin.m2m2.vo.User;
+import com.serotonin.m2m2.vo.publish.PublishedPointVO;
+import com.serotonin.m2m2.vo.publish.PublisherVO;
+import com.serotonin.m2m2.web.MediaTypes;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import net.jazdw.rql.parser.ASTNode;
+
+/**
+ * @author Terry Packer
+ *
+ */
+@Api(value="Mango Publishers")
+@RestController
+@RequestMapping("/publishers-v2")
+public class PublishersRestController<POINT extends PublishedPointVO, PUBLISHER extends PublisherVO<POINT>> {
+
+    private final PublisherService<POINT> service;
+    private final BiFunction<PublisherVO<?>, User, AbstractPublisherModel<?,?>> map;
+
+    @Autowired
+    public PublishersRestController(final PublisherService<POINT> service, final RestModelMapper modelMapper) {
+        this.service = service;
+        this.map = (vo, user) -> {
+            return modelMapper.map(vo, AbstractPublisherModel.class, user);
+        };
+    }
+
+    
+    @ApiOperation(
+            value = "Query Publishers Sources",
+            notes = "RQL Formatted Query",
+            responseContainer="List"
+            )
+    @RequestMapping(method = RequestMethod.GET)
+    public StreamedArrayWithTotal query(
+            HttpServletRequest request,
+            @ApiParam(value="User", required=true)
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder) {
+        ASTNode rql = RQLUtils.parseRQLtoAST(request.getQueryString());
+        return doQuery(rql, user);
+    }
+
+    @ApiOperation(
+            value = "Get publisher by XID",
+            notes = ""
+            )
+    @RequestMapping(method = RequestMethod.GET, value="/{xid}")
+    public AbstractPublisherModel<?,?> get(
+            @ApiParam(value = "XID of publisher", required = true, allowMultiple = false)
+            @PathVariable String xid,
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder) {
+        return map.apply(service.getFull(xid, user), user);
+    }
+
+    @ApiOperation(
+            value = "Get publisher by ID",
+            notes = ""
+            )
+    @RequestMapping(method = RequestMethod.GET, value="/by-id/{id}")
+    public AbstractPublisherModel<?,?> getById(
+            @ApiParam(value = "ID of publisher", required = true, allowMultiple = false)
+            @PathVariable int id,
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder) {
+        return map.apply(service.getFull(id, user), user);
+    }
+
+    @ApiOperation(value = "Save publisher")
+    @RequestMapping(method = RequestMethod.POST)
+    public ResponseEntity<AbstractPublisherModel<?,?>> save(
+            @RequestBody(required=true) AbstractPublisherModel<POINT, PUBLISHER> model,
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder,
+            HttpServletRequest request) {
+
+        PublisherVO<?> vo = this.service.insertFull(model.toVO(), user);
+        URI location = builder.path("/publishers-v2/{xid}").buildAndExpand(new Object[]{vo.getXid()}).toUri();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(location);
+        return new ResponseEntity<>(map.apply(vo, user), headers, HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "Update publisher")
+    @RequestMapping(method = RequestMethod.PUT, value = "/{xid}")
+    public ResponseEntity<AbstractPublisherModel<?,?>> update(
+            @PathVariable String xid,
+            @RequestBody(required=true) AbstractPublisherModel<POINT, PUBLISHER> model,
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder,
+            HttpServletRequest request) {
+
+        PublisherVO<?> vo = this.service.update(xid, model.toVO(), user);
+        URI location = builder.path("/publishers-v2/{xid}").buildAndExpand(new Object[]{vo.getXid()}).toUri();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(location);
+        return new ResponseEntity<>(map.apply(vo, user), headers, HttpStatus.OK);
+    }
+
+    @ApiOperation(
+            value = "Partially update a publisher",
+            notes = "Requires edit permission"
+            )
+    @RequestMapping(method = RequestMethod.PATCH, value = "/{xid}")
+    public ResponseEntity<AbstractPublisherModel<?,?>> partialUpdate(
+            @PathVariable String xid,
+
+            @ApiParam(value = "Updated data source", required = true)
+            @PatchVORequestBody(
+                    service=PublisherService.class,
+                    modelClass=AbstractPublisherModel.class)
+            AbstractPublisherModel<POINT, PUBLISHER> model,
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder) {
+
+        PublisherVO<?> vo = service.updateFull(xid, model.toVO(), user);
+
+        URI location = builder.path("/publishers-v2/{xid}").buildAndExpand(vo.getXid()).toUri();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(location);
+
+        return new ResponseEntity<>(map.apply(vo, user), headers, HttpStatus.OK);
+    }
+
+    @ApiOperation(
+            value = "Delete a publisher",
+            notes = "",
+            response=AbstractPublisherModel.class
+            )
+    @RequestMapping(method = RequestMethod.DELETE, value="/{xid}")
+    public AbstractPublisherModel<?,?> delete(
+            @ApiParam(value = "XID of publisher to delete", required = true, allowMultiple = false)
+            @PathVariable String xid,
+            @AuthenticationPrincipal User user,
+            UriComponentsBuilder builder) {
+        return map.apply(service.delete(xid, user), user);
+    }
+
+    @ApiOperation(value = "Enable/disable/restart a publisher")
+    @RequestMapping(method = RequestMethod.PUT, value = "/enable-disable/{xid}")
+    public void enableDisable(
+            @PathVariable String xid,
+
+            @ApiParam(value = "Enable or disable the publisher", required = true, allowMultiple = false)
+            @RequestParam(required=true) boolean enabled,
+
+            @ApiParam(value = "Restart the publisher, enabled must equal true", required = false, defaultValue="false", allowMultiple = false)
+            @RequestParam(required=false, defaultValue="false") boolean restart,
+
+            @AuthenticationPrincipal User user) {
+        service.restart(xid, enabled, restart, user);
+    }
+
+
+    @ApiOperation(
+            value = "Export formatted for Configuration Import",
+            notes = "")
+    @RequestMapping(method = RequestMethod.GET, value = "/export/{xid}", produces = MediaTypes.SEROTONIN_JSON_VALUE)
+    public Map<String, Object> exportDataSource(
+            @ApiParam(value = "Valid publisher XID", required = true, allowMultiple = false)
+            @PathVariable String xid,
+            @AuthenticationPrincipal User user) {
+
+        PublisherVO<?> vo = service.get(xid, user);
+        Map<String,Object> export = new LinkedHashMap<>();
+        export.put("publishers", Collections.singletonList(vo));
+        return export;
+    }
+
+    /**
+     * Perform a query
+     * @param rql
+     * @param user
+     * @return
+     */
+    private StreamedArrayWithTotal doQuery(ASTNode rql, User user) {
+        //If we are admin or have overall data source permission we can view all
+        if (user.hasAdminPermission()) {
+            return new StreamedVORqlQueryWithTotal<>(service, rql, vo -> map.apply(vo, user), true);
+        } else {
+            return new StreamedVORqlQueryWithTotal<>(service, rql, user, vo -> map.apply(vo, user), true);
+        }
+    }
+    
+}

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/AbstractVoModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/AbstractVoModel.java
@@ -15,7 +15,7 @@ import io.swagger.annotations.ApiModelProperty;
  *
  * @author Terry Packer
  */
-public abstract class AbstractVoModel<VO extends AbstractVO<VO>> {
+public abstract class AbstractVoModel<VO extends AbstractVO<?>> {
     
     @JsonInclude(JsonInclude.Include.NON_NULL)
     protected Integer id;

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/datasource/AbstractDataSourceModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/datasource/AbstractDataSourceModel.java
@@ -34,9 +34,6 @@ public abstract class AbstractDataSourceModel<T extends DataSourceVO<T>> extends
 
     public static final String MODEL_TYPE = "modelType";
 
-    @JsonIgnore
-    protected DataSourceDefinition definition;
-
     @ApiModelProperty("Read only description of data source connection")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private TranslatableMessage connectionDescription;
@@ -81,7 +78,6 @@ public abstract class AbstractDataSourceModel<T extends DataSourceVO<T>> extends
     @Override
     public void fromVO(T vo) {
         super.fromVO(vo);
-        this.definition = vo.getDefinition();
         this.connectionDescription = vo.getConnectionDescription();
         this.description = new TranslatableMessage(vo.getDefinition().getDescriptionKey());
 
@@ -92,7 +88,6 @@ public abstract class AbstractDataSourceModel<T extends DataSourceVO<T>> extends
         for(EventTypeVO evt : vo.getEventTypes()) {
             DataSourceEventType dsEvt = (DataSourceEventType)evt.getEventType();
             EventTypeAlarmLevelModel model = new EventTypeAlarmLevelModel(
-                    vo.getXid(),
                     eventCodes.getCode(dsEvt.getReferenceId2()),
                     dsEvt.getDuplicateHandling(),
                     dsEvt.getAlarmLevel(),

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/datasource/EventTypeAlarmLevelModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/datasource/EventTypeAlarmLevelModel.java
@@ -11,7 +11,8 @@ import com.serotonin.m2m2.rt.event.type.DuplicateHandling;
 import io.swagger.annotations.ApiModelProperty;
 
 /**
- * Container to allow adjusting the alarm levels for a given data source's
+ * Container to allow adjusting the alarm levels for a given data source 
+ * or publisher's
  * alarms.
  *
  * @author Terry Packer
@@ -35,13 +36,12 @@ public class EventTypeAlarmLevelModel {
     public EventTypeAlarmLevelModel() { }
 
     /**
-     * @param dataSourceXid
      * @param eventType
      * @param duplicateHandling
      * @param level
      * @param description
      */
-    public EventTypeAlarmLevelModel(String dataSourceXid, String eventType,
+    public EventTypeAlarmLevelModel(String eventType,
             DuplicateHandling duplicateHandling, AlarmLevels level,
             TranslatableMessage description) {
         super();

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/publisher/AbstractPublishedPointModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/publisher/AbstractPublishedPointModel.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2019  Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango.rest.v2.model.publisher;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.serotonin.m2m2.db.dao.DataPointDao;
+import com.serotonin.m2m2.vo.publish.PublishedPointVO;
+
+/**
+ * @author Terry Packer
+ *
+ */
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=AbstractPublishedPointModel.MODEL_TYPE)
+public abstract class AbstractPublishedPointModel<T extends PublishedPointVO> {
+    public static final String MODEL_TYPE = "modelType";
+
+    protected String dataPointXid;
+    
+    public void fromVO(T vo) {
+        this.dataPointXid = DataPointDao.getInstance().getXidById(vo.getDataPointId());
+    }
+
+    /**
+     * Return the TYPE_NAME for the point's model
+     * @return
+     */
+    public abstract String getModelType();
+    
+    /**
+     * Create a vo from our fields
+     * @return
+     */
+    public T toVO() {
+        T vo = newVO();
+        Integer id = DataPointDao.getInstance().getIdByXid(dataPointXid);
+        if(id != null)
+            vo.setDataPointId(id);
+        return vo;
+    }
+    
+    /**
+     * Create an empty published point
+     * @return
+     */
+    public abstract T newVO();
+    
+    public String getDataPointXid() {
+        return dataPointXid;
+    }
+    
+    public void setDataPointXid(String dataPointXid) {
+        this.dataPointXid = dataPointXid;
+    }
+}

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/publisher/AbstractPublisherModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/publisher/AbstractPublisherModel.java
@@ -3,12 +3,25 @@
  */
 package com.infiniteautomation.mango.rest.v2.model.publisher;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.infiniteautomation.mango.rest.v2.exception.GenericRestException;
 import com.infiniteautomation.mango.rest.v2.model.AbstractVoModel;
+import com.infiniteautomation.mango.rest.v2.model.datasource.EventTypeAlarmLevelModel;
+import com.infiniteautomation.mango.rest.v2.model.time.TimePeriod;
+import com.infiniteautomation.mango.rest.v2.model.time.TimePeriodType;
 import com.serotonin.m2m2.i18n.TranslatableMessage;
+import com.serotonin.m2m2.module.ModuleRegistry;
 import com.serotonin.m2m2.module.PublisherDefinition;
+import com.serotonin.m2m2.rt.event.type.PublisherEventType;
+import com.serotonin.m2m2.util.ExportCodes;
+import com.serotonin.m2m2.vo.event.EventTypeVO;
 import com.serotonin.m2m2.vo.publish.PublishedPointVO;
 import com.serotonin.m2m2.vo.publish.PublisherVO;
 
@@ -19,7 +32,7 @@ import io.swagger.annotations.ApiModelProperty;
  *
  */
 @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=AbstractPublisherModel.MODEL_TYPE)
-public class AbstractPublisherModel<T extends PublishedPointVO> extends AbstractVoModel<PublisherVO<T>>{
+public abstract class AbstractPublisherModel<POINT extends PublishedPointVO, PUBLISHER extends PublisherVO<POINT>> extends AbstractVoModel<PUBLISHER> {
     
     public static final String MODEL_TYPE = "modelType";
 
@@ -28,16 +41,216 @@ public class AbstractPublisherModel<T extends PublishedPointVO> extends Abstract
     
     @ApiModelProperty("Read only description of publisher connection")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private TranslatableMessage connectionDescription;
+    protected TranslatableMessage connectionDescription;
 
     @ApiModelProperty("Read only description of publisher type")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private TranslatableMessage description;
+    protected TranslatableMessage description;
 
+    protected boolean enabled;
+    protected List<EventTypeAlarmLevelModel> eventAlarmLevels;
+    protected List<AbstractPublishedPointModel<POINT>> points = new ArrayList<>();
+    protected String publishType;
+    protected int cacheWarningSize;
+    protected int cacheDiscardSize;
+    protected boolean sendSnapshot;
+    protected TimePeriod snapshotSendPeriod;
+    protected boolean publishAttributeChanges;
+    
+    
+    /**
+     * Return the TYPE_NAME from the Publisher Source definition
+     * @return
+     */
+    public abstract String getModelType();
+    
+    /**
+     * Model a point
+     * @param point
+     * @return
+     */
+    public abstract AbstractPublishedPointModel<POINT> modelPoint(POINT point);
+
+    @SuppressWarnings("unchecked")
     @Override
-    protected PublisherVO<T> newVO() {
-        // TODO Auto-generated method stub
-        return null;
+    protected PUBLISHER newVO() {
+        PublisherDefinition def = getDefinition();
+        PUBLISHER vo = (PUBLISHER) def.baseCreatePublisherVO();
+        vo.setDefinition(def);
+        return vo;
+    }
+    
+    @JsonIgnore
+    public PublisherDefinition getDefinition() {
+        PublisherDefinition definition = ModuleRegistry.getPublisherDefinition(getModelType());
+        if(definition == null)
+            throw new GenericRestException(HttpStatus.NOT_ACCEPTABLE, new TranslatableMessage("rest.exception.modelNotFound", getModelType()));
+        return definition;
+    }
+    
+    @Override
+    public void fromVO(PUBLISHER vo) {
+        super.fromVO(vo);
+        this.connectionDescription = vo.getConfigDescription();
+        this.description = new TranslatableMessage(vo.getDefinition().getDescriptionKey());
+
+        this.enabled = vo.isEnabled();
+        this.eventAlarmLevels = new ArrayList<>();
+        ExportCodes eventCodes = vo.getEventCodes();
+        
+        for(EventTypeVO evt : vo.getEventTypes()) {
+            PublisherEventType dsEvt = (PublisherEventType)evt.getEventType();
+            EventTypeAlarmLevelModel model = new EventTypeAlarmLevelModel(
+                    eventCodes.getCode(dsEvt.getReferenceId2()),
+                    dsEvt.getDuplicateHandling(),
+                    evt.getAlarmLevel(),
+                    evt.getDescription()
+                    );
+            this.eventAlarmLevels.add(model);
+        }
+        
+        this.points = new ArrayList<>();
+        for(POINT point : vo.getPoints()) {
+            this.points.add(modelPoint(point));
+        }
+        
+        this.publishType = PublisherVO.PUBLISH_TYPE_CODES.getCode(vo.getPublishType());
+        this.cacheWarningSize = vo.getCacheWarningSize();
+        this.cacheDiscardSize = vo.getCacheDiscardSize();
+        this.sendSnapshot = vo.isSendSnapshot();
+        this.snapshotSendPeriod = new TimePeriod(vo.getSnapshotSendPeriods(), TimePeriodType.convertTo(vo.getSnapshotSendPeriodType()));
+        this.publishAttributeChanges = vo.isPublishAttributeChanges();
+    }
+    
+    @Override
+    public PUBLISHER toVO() {
+        PUBLISHER vo = super.toVO();
+        vo.setEnabled(enabled);
+        
+        if(eventAlarmLevels != null) {
+            for(EventTypeAlarmLevelModel eval : eventAlarmLevels) {
+                vo.setAlarmLevel(eval.getEventType(), eval.getLevel());
+            }
+        }
+        
+        if(points != null) {
+            List<POINT> pointVos = new ArrayList<>();
+            for(AbstractPublishedPointModel<POINT> pm : points)
+                pointVos.add(pm.toVO());
+            vo.setPoints(pointVos);
+        }
+        
+        vo.setPublishType(PublisherVO.PUBLISH_TYPE_CODES.getId(publishType));
+        vo.setCacheWarningSize(cacheWarningSize);
+        vo.setCacheDiscardSize(cacheDiscardSize);
+        vo.setSendSnapshot(sendSnapshot);
+        if(snapshotSendPeriod != null) {
+            vo.setSnapshotSendPeriods(snapshotSendPeriod.getPeriods());
+            vo.setSnapshotSendPeriodType(TimePeriodType.convertFrom(snapshotSendPeriod.getType()));
+        }
+        vo.setPublishAttributeChanges(publishAttributeChanges);
+        return vo;
+    }
+    
+    
+    /**
+     * Get the description for the publisher's connection
+     * @return
+     */
+    public TranslatableMessage getConnectionDescription() {
+        return connectionDescription;
     }
 
+    /**
+     * Get the description for the type of publisher
+     * @return
+     */
+    public TranslatableMessage getDescription() {
+        return description;
+    }
+
+    /**
+     * Get the description translation key for the type of publisher
+     * @return
+     */
+    public String getDescriptionKey() {
+        return description.getKey();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public List<EventTypeAlarmLevelModel> getEventAlarmLevels() {
+        return eventAlarmLevels;
+    }
+
+    public void setEventAlarmLevels(List<EventTypeAlarmLevelModel> alarmLevels) {
+        this.eventAlarmLevels = alarmLevels;
+    }
+
+    public String getPublishType() {
+        return publishType;
+    }
+
+    public void setPublishType(String publishType) {
+        this.publishType = publishType;
+    }
+
+    public int getCacheWarningSize() {
+        return cacheWarningSize;
+    }
+
+    public void setCacheWarningSize(int cacheWarningSize) {
+        this.cacheWarningSize = cacheWarningSize;
+    }
+
+    public int getCacheDiscardSize() {
+        return cacheDiscardSize;
+    }
+
+    public void setCacheDiscardSize(int cacheDiscardSize) {
+        this.cacheDiscardSize = cacheDiscardSize;
+    }
+
+    public boolean isSendSnapshot() {
+        return sendSnapshot;
+    }
+
+    public void setSendSnapshot(boolean sendSnapshot) {
+        this.sendSnapshot = sendSnapshot;
+    }
+
+    public TimePeriod getSnapshotSendPeriod() {
+        return snapshotSendPeriod;
+    }
+
+    public void setSnapshotSendPeriod(TimePeriod snapshotSendPeriod) {
+        this.snapshotSendPeriod = snapshotSendPeriod;
+    }
+
+    public boolean isPublishAttributeChanges() {
+        return publishAttributeChanges;
+    }
+
+    public void setPublishAttributeChanges(boolean publishAttributeChanges) {
+        this.publishAttributeChanges = publishAttributeChanges;
+    }
+
+    public void setConnectionDescription(TranslatableMessage connectionDescription) {
+        this.connectionDescription = connectionDescription;
+    }
+
+    public List<AbstractPublishedPointModel<POINT>> getPoints() {
+        return points;
+    }
+
+    public void setPoints(List<AbstractPublishedPointModel<POINT>> points) {
+        this.points = points;
+    }
+    
 }

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/publisher/AbstractPublisherModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/publisher/AbstractPublisherModel.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2019  Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango.rest.v2.model.publisher;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.infiniteautomation.mango.rest.v2.model.AbstractVoModel;
+import com.serotonin.m2m2.i18n.TranslatableMessage;
+import com.serotonin.m2m2.module.PublisherDefinition;
+import com.serotonin.m2m2.vo.publish.PublishedPointVO;
+import com.serotonin.m2m2.vo.publish.PublisherVO;
+
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * @author Terry Packer
+ *
+ */
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.EXISTING_PROPERTY, property=AbstractPublisherModel.MODEL_TYPE)
+public class AbstractPublisherModel<T extends PublishedPointVO> extends AbstractVoModel<PublisherVO<T>>{
+    
+    public static final String MODEL_TYPE = "modelType";
+
+    @JsonIgnore
+    protected PublisherDefinition definition;
+    
+    @ApiModelProperty("Read only description of publisher connection")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private TranslatableMessage connectionDescription;
+
+    @ApiModelProperty("Read only description of publisher type")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private TranslatableMessage description;
+
+    @Override
+    protected PublisherVO<T> newVO() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/websocket/dao/PublisherWebSocketHandler.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/websocket/dao/PublisherWebSocketHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2019  Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango.rest.v2.websocket.dao;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.infiniteautomation.mango.rest.v2.model.RestModelMapper;
+import com.infiniteautomation.mango.rest.v2.model.publisher.AbstractPublisherModel;
+import com.infiniteautomation.mango.rest.v2.websocket.DaoNotificationWebSocketHandler;
+import com.infiniteautomation.mango.rest.v2.websocket.WebSocketMapping;
+import com.infiniteautomation.mango.spring.events.DaoEvent;
+import com.infiniteautomation.mango.spring.service.PublisherService;
+import com.serotonin.m2m2.vo.User;
+import com.serotonin.m2m2.vo.publish.PublishedPointVO;
+import com.serotonin.m2m2.vo.publish.PublisherVO;
+
+/**
+ * @author Terry Packer
+ *
+ */
+@Component("PublisherWebSocketHandlerV2")
+@WebSocketMapping("/websocket/publishers")
+public class PublisherWebSocketHandler <POINT extends PublishedPointVO, PUBLISHER extends PublisherVO<POINT>> extends DaoNotificationWebSocketHandler<PUBLISHER>{
+
+    private final PublisherService<POINT> service;
+    private final RestModelMapper modelMapper;
+
+    @Autowired
+    public PublisherWebSocketHandler(PublisherService<POINT> service, RestModelMapper modelMapper) {
+        this.service = service;
+        this.modelMapper = modelMapper;
+    }
+
+    @Override
+    protected boolean hasPermission(User user, PUBLISHER vo) {
+        return service.hasReadPermission(user, vo);
+    }
+
+    @Override
+    protected Object createModel(PUBLISHER vo) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object createModel(PUBLISHER vo, User user) {
+        return modelMapper.map(vo, AbstractPublisherModel.class, user);
+    }
+
+    @Override
+    @EventListener
+    protected void handleDaoEvent(DaoEvent<? extends PUBLISHER> event) {
+        this.notify(event);
+    }
+
+    @Override
+    protected boolean isModelPerUser() {
+        return true;
+    }
+}


### PR DESCRIPTION
Adding a new publisher endpoint that will work like the data source v2 endpoint so that writing the publisher UI will be easier so we can leverage some of the work from the data sources.  There was already a publishers v2 endpoint so I put this one at `rest/v2/publishers-v2`

There was not a web socket for v2 so that is at rest/v2/publishers
