### PR TITLE
Public user registration

### DIFF
--- a/Mango API/RELEASE-NOTES
+++ b/Mango API/RELEASE-NOTES
@@ -4,6 +4,10 @@
 * Add endpoint /v2/server/email/mailing-list/{xid} to allow users to send emails to a mailing list
 * Add endpoint /v2/server/email to allow admins to send email to any Mango user
 * Adding high performant point value import endpoint for CSV and JSON at v2/point-value-modification/import
+* Adding /v2/users/registration/public/send-email to allow public user registration see Core env property web.security.publicRegistrationEnabled to enable
+* Adding /v2/users/registration/send-email for users to request an emailed token to verify their email addresses
+* Adding /v2/users/registration/public/verify-email for users to publicly verify their email addresses
+* Adding /v2/users/registration/verify-email for users to verify their email addresses
 
 *Version 3.6.3*
 * Fix point values v2 endpoint to use rendered unit when writing analog statistics

--- a/Mango API/api-test/userV2.spec.js
+++ b/Mango API/api-test/userV2.spec.js
@@ -43,7 +43,14 @@ describe('User V2 endpoint tests', function() {
                 periods: 1,
                 type: 'SECONDS'
             },
-            organization: 'Infinite Automation Systems'
+            organization: 'Infinite Automation Systems',
+            organizationalRole: 'test engineer',
+            data: {
+                stringField: 'some random string',
+                numberField: 123,
+                booleanField: true
+            }
+                
         };
         return client.restRequest({
             path: '/rest/v2/users',
@@ -52,6 +59,10 @@ describe('User V2 endpoint tests', function() {
         }).then(response => {
             assert.equal(response.data.username, this.testUser.username);
             assert.strictEqual(response.data.organization, this.testUser.organization);
+            assert.strictEqual(response.data.organizationalRole, this.testUser.organizationalRole);
+            assert.strictEqual(response.data.data.stringField, this.testUser.data.stringField);
+            assert.strictEqual(response.data.data.numberField, this.testUser.data.numberField);
+            assert.strictEqual(response.data.data.booleanField, this.testUser.data.booleanField);
             this.testUser.id = response.data.id;
         });
     });
@@ -63,7 +74,7 @@ describe('User V2 endpoint tests', function() {
             name: 'admin name',
             username: username,
             password: this.testAdminUserPassword,
-            email: 'test@test.com',
+            email: 'admin@test.com',
             phone: '808-888-8888',
             disabled: false,
             locale: '',

--- a/Mango API/classes/i18n.properties
+++ b/Mango API/classes/i18n.properties
@@ -41,7 +41,8 @@ rest.error.rejectedTaskAlreadyRunning=Task rejected, already running
 rest.error.dataSourceNotEnabled=Data source for point with xid {0} is not enabled
 rest.error.invalidUpgradeFile=Invalid upgrade file, this is not a signed module, zip of signed modules or signed core zip
 rest.error.upgradeUploadInProgress=Upgrade upload already in progress
-
+rest.error.invalidEmailVerificationToken=Invalid email verification token
+rest.error.cannotValidateAnotherUsersEmail=Only admins can request to validate other users email addresses
 #Modules
 rest.modules.error.dependencyFailure=Dependencies prevented marking for deletion
 

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/UserRestController.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/UserRestController.java
@@ -4,17 +4,21 @@
  */
 package com.infiniteautomation.mango.rest.v2;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
 
+import javax.mail.internet.AddressException;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,19 +31,33 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.infiniteautomation.mango.rest.v2.exception.AccessDeniedException;
+import com.infiniteautomation.mango.rest.v2.exception.BadRequestException;
 import com.infiniteautomation.mango.rest.v2.model.StreamedArrayWithTotal;
 import com.infiniteautomation.mango.rest.v2.model.StreamedVORqlQueryWithTotal;
 import com.infiniteautomation.mango.rest.v2.model.user.UserModel;
 import com.infiniteautomation.mango.rest.v2.patch.PatchVORequestBody;
 import com.infiniteautomation.mango.rest.v2.patch.PatchVORequestBody.PatchIdField;
+import com.infiniteautomation.mango.spring.components.EmailAddressVerificationService;
 import com.infiniteautomation.mango.spring.service.UsersService;
 import com.infiniteautomation.mango.util.RQLUtils;
+import com.serotonin.m2m2.Common;
+import com.serotonin.m2m2.i18n.ProcessResult;
 import com.serotonin.m2m2.i18n.TranslatableMessage;
 import com.serotonin.m2m2.vo.User;
+import com.serotonin.m2m2.vo.Validatable;
 import com.serotonin.m2m2.vo.permission.PermissionDetails;
+import com.serotonin.m2m2.vo.permission.PermissionException;
+import com.serotonin.m2m2.vo.permission.Permissions;
 import com.serotonin.m2m2.web.mvc.rest.v1.exception.RestValidationFailedException;
 import com.serotonin.m2m2.web.mvc.spring.security.MangoSessionRegistry;
 
+import freemarker.template.TemplateException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.IncorrectClaimException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.MissingClaimException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -57,11 +75,13 @@ public class UserRestController {
     private final BiFunction<User, User, UserModel> map = (vo, user) -> {return new UserModel(vo);};
     private final UsersService service;
     private final MangoSessionRegistry sessionRegistry;
+    private final EmailAddressVerificationService emailConfirmationService;
     
     @Autowired
-    public UserRestController(UsersService service, MangoSessionRegistry sessionRegistry) {
+    public UserRestController(UsersService service, MangoSessionRegistry sessionRegistry, EmailAddressVerificationService emailConfirmationService) {
         this.service = service;
         this.sessionRegistry = sessionRegistry;
+        this.emailConfirmationService = emailConfirmationService;
     }
     
     @ApiOperation(
@@ -296,6 +316,70 @@ public class UserRestController {
         return service.getUserGroups(exclude, user);
     }
 
+    
+    
+    @ApiOperation(value = "Public endpoint that sends an email containing an email confirmation link", notes="This endpoint is for new users, existing users will recieve a warning email")
+    @RequestMapping(method = RequestMethod.POST, value = "/registration/public/send-email")
+    public ResponseEntity<Void> sendEmailPublic(@RequestBody String emailAddress) throws AddressException, TemplateException, IOException {
+
+        //Is the system property set
+        if(!Common.envProps.getBoolean("web.security.publicRegistrationEnabled", false)) {
+            throw new AccessDeniedException();
+        }
+        
+        emailConfirmationService.sendEmail(emailAddress, null);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+    
+    @ApiOperation(value = "Sends an email containing an email confirmation link for a given user")
+    @RequestMapping(method = RequestMethod.POST, value = "/registration/send-email")
+    public ResponseEntity<Void> sendEmail(
+            @RequestBody int userId,
+            @AuthenticationPrincipal User user) throws AddressException, TemplateException, IOException {
+
+        if(!Permissions.hasAdminPermission(user) && userId != user.getId()) {
+            throw new PermissionException(new TranslatableMessage("rest.error.cannotValidateAnotherUsersEmail"), user);
+        }
+        emailConfirmationService.sendEmail(service.get(userId, user), null);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+    
+    @ApiOperation(value = "Public endpoint to verify the user's email if the token is correct", notes="If a User model is supplied and this is a new user, a new disabled user is created")
+    @RequestMapping(method = RequestMethod.POST, value = "/registration/public/verify-email")
+    public ResponseEntity<Void> verify(
+            @RequestBody EmailVerificationRequestBody body) {
+
+        body.ensureValid();
+        try {
+            User newUser = body.getUser().toVO();
+            emailConfirmationService.verifyEmail(body.getToken(), newUser);
+        } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | IllegalArgumentException | SignatureException | MissingClaimException | IncorrectClaimException e) {
+            throw new BadRequestException(new TranslatableMessage("rest.error.invalidEmailVerificationToken"), e);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+    
+    @ApiOperation(value = "Verifies the user's email if the token is correct", notes="")
+    @RequestMapping(method = RequestMethod.POST, value = "/registration/verify-email")
+    public ResponseEntity<Void> verifyPublic(
+            @RequestBody String token) {
+        try {
+            emailConfirmationService.verifyEmail(token);
+        } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | IllegalArgumentException | SignatureException | MissingClaimException | IncorrectClaimException e) {
+            throw new BadRequestException(new TranslatableMessage("rest.error.invalidEmailVerificationToken"), e);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    
+    @ApiOperation(value = "Resets the public and private keys", notes = "Will invalidate all email verification tokens")
+    @RequestMapping(path="/registration/reset-keys", method = RequestMethod.POST)
+    @PreAuthorize("isAdmin()")
+    public ResponseEntity<Void> resetKeys() {
+        emailConfirmationService.resetKeys();
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+    
     public StreamedArrayWithTotal doQuery(ASTNode rql, User user) {
         
         if (user.hasAdminPermission()) {
@@ -306,4 +390,31 @@ public class UserRestController {
             return new StreamedVORqlQueryWithTotal<>(service, rql, user, vo -> map.apply(vo, user), false);
         }
     } 
+    
+    public static class EmailVerificationRequestBody implements Validatable {
+        private String token;
+        private UserModel user;
+        public String getToken() {
+            return token;
+        }
+        public void setToken(String token) {
+            this.token = token;
+        }
+        public UserModel getUser() {
+            return user;
+        }
+        public void setUser(UserModel user) {
+            this.user = user;
+        }
+        @Override
+        public void validate(ProcessResult response) {
+            if(StringUtils.isEmpty(token)) {
+                response.addContextualMessage("token", "validate.required");
+            }
+            if(user == null) {
+                response.addContextualMessage("user", "validate.required");
+            }
+        }
+        
+    }
 }

--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/user/UserModel.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/user/UserModel.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.infiniteautomation.mango.rest.v2.model.AbstractVoModel;
 import com.infiniteautomation.mango.rest.v2.model.time.TimePeriod;
 import com.infiniteautomation.mango.rest.v2.model.time.TimePeriodType;
@@ -44,6 +45,10 @@ public class UserModel extends AbstractVoModel<User> {
     private boolean sessionExpirationOverride;
     private TimePeriod sessionExpirationPeriod;
     private String organization;
+    private String organizationalRole;
+    private Date created;
+    private Date emailVerified;
+    private JsonNode data;
     
     @ApiModelProperty("List of system settings permission definitions this user has access to")
     private Set<String> grantedPermissions;
@@ -175,6 +180,30 @@ public class UserModel extends AbstractVoModel<User> {
         this.organization = organization;
     }
     
+    public String getOrganizationalRole() {
+        return organizationalRole;
+    }
+    
+    public void setOrganizationalRole(String organizationalRole) {
+        this.organizationalRole = organizationalRole;
+    }
+    
+    public Date getCreated() {
+        return created;
+    }
+    
+    public Date getEmailVerified() {
+        return emailVerified;
+    }
+
+    public JsonNode getData() {
+        return data;
+    }
+    
+    public void setData(JsonNode data) {
+        this.data = data;
+    }
+    
     public boolean isOldHashAlgorithm() {
         //New Users have null passwords
         if(password == null)
@@ -224,6 +253,12 @@ public class UserModel extends AbstractVoModel<User> {
                 this.grantedPermissions.add(grant.getTypeName());
         }
         this.organization = vo.getOrganization();
+        this.organizationalRole = vo.getOrganizationalRole();
+        this.created = new Date(vo.getCreatedTs());
+        if(vo.getEmailVerifiedTs() > 0) {
+            this.emailVerified = new Date(vo.getEmailVerifiedTs());
+        }
+        this.data = vo.getData();
     }
 
     @Override
@@ -254,6 +289,9 @@ public class UserModel extends AbstractVoModel<User> {
                 user.setSessionExpirationPeriodType(sessionExpirationPeriod.getType().name());
         }
         user.setOrganization(organization);
+        user.setOrganizationalRole(organizationalRole);
+        user.setData(data);
+        
         return user;
     }
 }

--- a/Mango API/src/com/serotonin/m2m2/web/mvc/rest/v1/model/user/UserModel.java
+++ b/Mango API/src/com/serotonin/m2m2/web/mvc/rest/v1/model/user/UserModel.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.serotonin.m2m2.Common;
 import com.serotonin.m2m2.i18n.ProcessMessage;
 import com.serotonin.m2m2.i18n.ProcessResult;
@@ -385,6 +386,32 @@ public class UserModel extends AbstractRestModel<User> {
     
     public void setOrganization(String organization) {
         this.data.setOrganization(organization);
+    }
+    
+    public String getOrganizationalRole() {
+        return data.getOrganizationalRole();
+    }
+    
+    public void setOrganizationalRole(String organizationalRole) {
+        this.data.setOrganizationalRole(organizationalRole);
+    }
+    
+    public Date getCreated() {
+        return new Date(this.data.getCreatedTs());
+    }
+    
+    public Date getEmailVerified() {
+        return new Date(this.data.getEmailVerifiedTs());
+    }
+
+    @JsonGetter("data")
+    public JsonNode getUserData() {
+        return this.data.getData();
+    }
+    
+    @JsonSetter("data")
+    public void setUserData(JsonNode data) {
+        this.data.setData(data);
     }
     
     public List<RestValidationMessage> getMessages() {


### PR DESCRIPTION
This is part of the fixes for:

infiniteautomation/ma-core-public#1484 and infiniteautomation/ma-core-public#1485

Adding public and private endpoints to verify email addresses and publicly created disabled users

See also for the necessary core code:
https://github.com/infiniteautomation/ma-core-public/pull/1491
