### PR TITLE
Fix bug where point value was always returning rendered value

### DIFF
--- a/Mango API/src/com/infiniteautomation/mango/rest/v2/model/pointValue/PointValueTimeWriter.java
+++ b/Mango API/src/com/infiniteautomation/mango/rest/v2/model/pointValue/PointValueTimeWriter.java
@@ -141,7 +141,7 @@ public abstract class PointValueTimeWriter {
                         writeIntegerField(name, value.getIntegerValue());
                         break;
                     case DataTypes.NUMERIC:
-                        if(vo.getRenderedUnit() != Unit.ONE)
+                        if(rendered && vo.getRenderedUnit() != Unit.ONE)
                             writeDoubleField(name, vo.getUnit().getConverterTo(vo.getRenderedUnit()).convert(value.getDoubleValue()));
                         else
                             writeDoubleField(name, value.getDoubleValue());


### PR DESCRIPTION
@jazdw I found a bug in the REST api that when fixed will affect the UI so I'm making this PR so you can evaluate if we want to fix it.  The v2 endpoints allow you to choose what fields are returned so when one asks for RENDERED and VALUE these should be different if the point has a rendered unit.  However the code was not checking the rendered flag when returning VALUE and instead was always returning the converted value for VALUE if the point had a rendered unit.  

So for example the latest values endpoint:
`rest/v2/point-values/latest/voltage?fields=RENDERED,VALUE,TIMESTAMP`
Without the fix:

```
{
  "rendered" : "940.67 mV",
  "value" : 940.6747853450748,
  "timestamp" : 1582924375933
}
```

With the fix
```
 {
  "rendered" : "960.67 mV",
  "value" : 0.9606747392584319,
  "timestamp" : 1582924305933
}
```

I can see the chart in the UI on the data point details page has a problem with this.  I'm wondering if we should provide another option in the fields for RAW or something.  That way it won't effect the UI.

After writing this I'm starting to remember we may have put that conversion code in there on purpose so the charts look right?