### PR TITLE
Added more intuivite hint so user knows which key adds a value

### DIFF
--- a/Virtual Data Source/RELEASE-NOTES
+++ b/Virtual Data Source/RELEASE-NOTES
@@ -1,6 +1,7 @@
 *Version 4.0.0*
 * Upgraded to work with core version 4.0.x
 * Remove v1 REST support
+* Added hint text indicating which keyboard key adds a value to the Multistate values chips
 
 *Version 3.7.0*
 * Upgraded to work with core version 3.7.x

--- a/Virtual Data Source/classes/i18n.properties
+++ b/Virtual Data Source/classes/i18n.properties
@@ -35,6 +35,7 @@ dsEdit.virtual.changeType.noChange=No change
 dsEdit.virtual.changeType.random=Random
 dsEdit.virtual.changeType.sinusoidal=Sinusoidal
 dsEdit.virtual.performPolling=Enable polling
+dsEdit.virtual.multistateChipHint=Press enter to save value
 
 virtual.error.attractor.missingPoint=Data point with ''{0}'' XID ''{1}'' not found
 

--- a/Virtual Data Source/classes/i18n.properties
+++ b/Virtual Data Source/classes/i18n.properties
@@ -35,7 +35,7 @@ dsEdit.virtual.changeType.noChange=No change
 dsEdit.virtual.changeType.random=Random
 dsEdit.virtual.changeType.sinusoidal=Sinusoidal
 dsEdit.virtual.performPolling=Enable polling
-dsEdit.virtual.multistateChipHint=Press enter to save value
+dsEdit.virtual.multistateChipHint=Press ENTER in order to save value
 
 virtual.error.attractor.missingPoint=Data point with ''{0}'' XID ''{1}'' not found
 

--- a/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.css
+++ b/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.css
@@ -11,9 +11,8 @@ ma-virtual-data-point-editor ma-filtering-point-list {
     margin-left: 10px;
 }
 
-ma-virtual-data-point-editor .hint {
+ma-virtual-data-point-editor .ma-hint {
     font-size: 16px;
-    color: #c0c0c0;
     display: block;
     margin-top: 8px;
   }

--- a/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.css
+++ b/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.css
@@ -10,3 +10,10 @@ ma-virtual-data-point-editor .close-icon {
 ma-virtual-data-point-editor ma-filtering-point-list {
     margin-left: 10px;
 }
+
+ma-virtual-data-point-editor .hint {
+    font-size: 16px;
+    color: #c0c0c0;
+    display: block;
+    margin-top: 8px;
+  }

--- a/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.html
+++ b/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.html
@@ -80,6 +80,8 @@
             <input name="value" type="number" ng-value="$ctrl.pointValue" ma-tr="common.value" ma-form-exclude>
         </md-chips>
 
+        <div class="hint" ma-tr="dsEdit.virtual.multistateChipHint"></div>
+
         <div ng-messages="values.$error">
             <div ng-message="required" ma-tr="validate.required"></div>
             <div ng-message="validationMessage" ng-bind="valuesModelCtrl.validationMessage"></div>

--- a/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.html
+++ b/Virtual Data Source/web-src/components/virtualDataPointEditor/virtualDataPointEditor.html
@@ -80,7 +80,7 @@
             <input name="value" type="number" ng-value="$ctrl.pointValue" ma-tr="common.value" ma-form-exclude>
         </md-chips>
 
-        <div class="hint" ma-tr="dsEdit.virtual.multistateChipHint"></div>
+        <div class="ma-hint" ma-tr="dsEdit.virtual.multistateChipHint" md-colors="::{color: 'background-400'}"></div>
 
         <div ng-messages="values.$error">
             <div ng-message="required" ma-tr="validate.required"></div>


### PR DESCRIPTION
Potential solution to #53 

Added hint text to indicate that the enter key must be pressed in order to save multistate state value. Regarding the question made: 

> if one adds a state, selects it as a start value, and then deletes the state from the state list, this will allow one to save. But, subsequent edits of the point will not save because the start value isn't found in the populated start value drop down list.

I consider this behavior to be expected as the point editor can't save because the prior start value was deleted. How must I proceed on this? 