### PR TITLE
[MANGO-1421] Authentication events are generated every time a request containing a bearer token is received

### DIFF
--- a/Mango API/api-test/tokenAuth.spec.js
+++ b/Mango API/api-test/tokenAuth.spec.js
@@ -577,11 +577,15 @@ describe('JSON Web Token authentication', function() {
         let lastLoginTime;
         return client.User.current().then(user => {
             lastLoginTime = user.lastLogin;
-            return this.createToken()
+            return this.createToken();
         }).then(token => {
             const jwtClient = createClient(this.noCookieConfig);
             jwtClient.setBearerAuthentication(token);
+            // use the token
             return jwtClient.User.current();
+        }).then(() => {
+            // get the current user again using session login client
+            return client.User.current();
         }).then(user => {
             assert.strictEqual(user.lastLogin, lastLoginTime);
         });

--- a/Mango API/api-test/tokenAuth.spec.js
+++ b/Mango API/api-test/tokenAuth.spec.js
@@ -572,4 +572,18 @@ describe('JSON Web Token authentication', function() {
             assert.isNumber(response.data);
         });
     });
+
+    it('Last login time is not updated when using JWT token to authenticate', function() {
+        let lastLoginTime;
+        return client.User.current().then(user => {
+            lastLoginTime = user.lastLogin;
+            return this.createToken()
+        }).then(token => {
+            const jwtClient = createClient(this.noCookieConfig);
+            jwtClient.setBearerAuthentication(token);
+            return jwtClient.User.current();
+        }).then(user => {
+            assert.strictEqual(user.lastLogin, lastLoginTime);
+        });
+    });
 });


### PR DESCRIPTION
## Description

Backported changes from mango 5 https://github.com/RadixIoT/mango/pull/638

## Jira tickets
- https://radixiot.atlassian.net/browse/MANGO-1051
- https://radixiot.atlassian.net/browse/MANGO-1421

## Description

- Fix regression introduced by https://radixiot.atlassian.net/browse/MANGO-1051
- Configures the `BearerTokenAuthenticationFilter` to use the `MangoAuthenticationDetailsSource` so that login events are not generated by using a JWT token